### PR TITLE
Update plasma-ontology.ttl

### DIFF
--- a/plasma-ontology.ttl
+++ b/plasma-ontology.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://plasma-mds.org/ontology#> .
+@prefix : <http://plasma-mds.org/ontology/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -10,7 +10,7 @@
 @prefix vivo: <http://vivoweb.org/ontology/core#> .
 @prefix datacite: <http://purl.org/spar/datacite/> .
 @prefix plasma-mds: <http://plasma-mds.org/ontology/> .
-@base <http://plasma-mds.org/ontology#> .
+@base <http://plasma-mds.org/ontology/> .
 
 <http://plasma-mds.org/ontology> rdf:type owl:Ontology ;
                                   owl:versionIRI plasma-mds:v.0.5 ;


### PR DESCRIPTION
Corrected namespace of the base.

This will solve the issue that a concept is shown as imported in an ols4 application.

Output after the correction:
![grafik](https://github.com/user-attachments/assets/1889f25c-3756-4d57-aa52-4161be6b97b3)